### PR TITLE
Minor updates to package metadata, URLs, dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "scmcoat"
@@ -20,3 +20,10 @@ classifiers = [
 [project.urls]
 "Homepage" = "https://github.com/kemccusker/scmcoat"
 "Bug Tracker" = "https://github.com/kemccusker/scmcoat/issues"
+
+dependencies = [
+    "fair~=1.6.4",
+    "numpy",
+    "pandas",
+    "xarray",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Wraps FaIR simple climate model with specific settings for use across projects"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,5 +18,5 @@ classifiers = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/pypa/sampleproject"
-"Bug Tracker" = "https://github.com/pypa/sampleproject/issues"
+"Homepage" = "https://github.com/kemccusker/scmcoat"
+"Bug Tracker" = "https://github.com/kemccusker/scmcoat/issues"


### PR DESCRIPTION
This has a few updates and fixes to the package setup and metadata:
- Updates the homepage and bug tracker URLs to match scmcoat's repo.
- Updates the required python version. I think we're using some features that aren't available in earlier Python versions.
- Adds package direct dependencies: numpy, pandas, xarray, fair. For `fair` set it to require versions compatible with fair v1.6.4. This should exclude fair v2.0.0. Changed the build system to `hatch` so we could do this.