### PR TITLE
Add tests/ for pytest, fix bad pkg name when getting test emissions

### DIFF
--- a/src/scmcoat/core/fair.py
+++ b/src/scmcoat/core/fair.py
@@ -287,7 +287,7 @@ class FaIRModel:
         import pandas as pd
         import pkg_resources
         
-        fn = pkg_resources.resource_filename("scmhug","testdata/rcp45emissions.csv")
+        fn = pkg_resources.resource_filename("scmcoat","testdata/rcp45emissions.csv")
 
         return pd.read_csv(fn)
     

--- a/tests/test_fair.py
+++ b/tests/test_fair.py
@@ -1,0 +1,14 @@
+import scmcoat.core.fair as fair
+
+
+def test_fairmodel_run():
+    """Test that FaIRModel.run runs on test_emissions without throwing exception
+    """
+    # initialize the model
+    fm = fair.FaIRModel()
+
+    # Open up the test emissions to use as a demo
+    emissions = fm.get_test_emissions()
+
+    # run FaIR with these emissions under its default settings
+    response = fm.run(emissions)


### PR DESCRIPTION
- Adds tests/ with test emission run test case. This doesn't actually check output, just tests it runs without raising an exception.
- Fixes a bug where `get_test_emissions()` errors because bad pkg name.

To run tests be sure `pytest` is installed and you've `pip install -e .` to get `scmcoat` as an installed package. Then run `pytest` from the repo's root. This test runs and passes. That's a good start.