### PR TITLE
Fix bad format bug, automatically set good package version on installs, build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,14 +16,13 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-
-[project.urls]
-"Homepage" = "https://github.com/kemccusker/scmcoat"
-"Bug Tracker" = "https://github.com/kemccusker/scmcoat/issues"
-
 dependencies = [
     "fair~=1.6.4",
     "numpy",
     "pandas",
     "xarray",
 ]
+
+[project.urls]
+"Homepage" = "https://github.com/kemccusker/scmcoat"
+"Bug Tracker" = "https://github.com/kemccusker/scmcoat/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,15 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "scmcoat"
-version = "0.0.1"
 authors = [
   { name="Kelly McCusker", email="kellymccusker@gmail.com" },
 ]
 description = "Wraps FaIR simple climate model with specific settings for use across projects"
 readme = "README.md"
+dynamic = ["version"]
 requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -26,3 +26,8 @@ dependencies = [
 [project.urls]
 "Homepage" = "https://github.com/kemccusker/scmcoat"
 "Bug Tracker" = "https://github.com/kemccusker/scmcoat/issues"
+
+
+[tool.hatch.version]
+source = "vcs"
+fallback-version = "999"


### PR DESCRIPTION
This is a small change that does a couple of things to make life muuch easier.

- Fixes bad pyproject.toml format introduced when I added dependencies in #1. Easy fix. My bad.
-  Use `hatch-vcs` plugin so package versions are automatically set based on git tags (like when doing a github release) or using the git commit hash when building and installing from dev versions. The idea is this will make it easier for users to upgrade the package or understand exactly what version they have installed when debugging dev versions.

This makes no change to how users install or build the package. All this happens behind the scenes.