### PR TITLE
Add automated CI testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,34 @@
+name: Python package
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Install package
+        run: |
+          pip install .
+      - name: Test with pytest
+        run: |
+          pytest -v


### PR DESCRIPTION
Automatically installs the package and pytest, then runs pytests. It runs on all pushes and pull requests to main branch.

This is a very simple start to get things rolling. I wouldn't be surprised if we need to build this out further later.

These tests will break and fail when the scmcoat package is installed in CI until the fix in #3 gets merged.