### PR TITLE
Refactor to cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,19 +50,19 @@ Here a `simulation` equal to `-1` indicates it's not running an ensemble of simu
 
 ## Examples: 
 ### Run v1.* FaIR with demo emissions (CMIP5 RCP4.5)
+
 ```python
 
-import scmcoat
-import scmcoat.core.fair as coat
+import scmcoat as sc
 
 # initialize the model
-fm = coat.FaIRModel()
+fm = sc.FairModel()
 
 # Open up the test emissions to use as a demo
 emissions = fm.get_test_emissions()
 
 # run FaIR with these emissions under its default settings
-response = fm.run(emissions) # an xr.Dataset
+response = fm.run(emissions)  # an xr.Dataset
 
 response.temperature.plot()
 

--- a/src/scmcoat/__init__.py
+++ b/src/scmcoat/__init__.py
@@ -1,0 +1,1 @@
+from scmcoat.core import FairModel

--- a/src/scmcoat/core.py
+++ b/src/scmcoat/core.py
@@ -4,7 +4,7 @@
     
     functions to run FaIR simple climate model given emissions
 """
-from ..types import ClimateParams, ClimateResponse #Emissions, 
+from scmcoat.types import ClimateParams, ClimateResponse #Emissions,
 
 import numpy as np
 import xarray as xr
@@ -50,7 +50,7 @@ FAIR_EMISSIONS_GASES = ['CO2_Fossil',
                 'CH3Br', 
                 'CH3Cl' ]
 
-class FaIRModel:
+class FairModel:
     """
         implementation of the ClimateModel Protocol
     """

--- a/tests/test_fair.py
+++ b/tests/test_fair.py
@@ -1,11 +1,10 @@
-import scmcoat.core.fair as fair
-
+import scmcoat as sc
 
 def test_fairmodel_run():
-    """Test that FaIRModel.run runs on test_emissions without throwing exception
+    """Test that FairModel.run runs on test_emissions without throwing exception
     """
     # initialize the model
-    fm = fair.FaIRModel()
+    fm = sc.FairModel()
 
     # Open up the test emissions to use as a demo
     emissions = fm.get_test_emissions()


### PR DESCRIPTION
Moves `scmcoat.core.fair.FaIRModel` to `scmcoat.core.FairModel`. Also allows direct import with `scmcoat.FairModel`.

This should simplify things and maybe make life easier.