### PR TITLE
add median climate params functionality

### DIFF
--- a/src/scmcoat/core.py
+++ b/src/scmcoat/core.py
@@ -114,7 +114,10 @@ class FairModel:
             return ret
         else:
 
-            args = self.params.sel(simulation=self.simid)
+            if self.simid == "median":
+                args = self.params.median_params
+            else:
+                args = self.params.params.sel(simulation=self.simid)
             if DEBUG:
                 print(f"Running FaIR, v{fair.__version__}. simid: {self.simid}")
             

--- a/src/scmcoat/types.py
+++ b/src/scmcoat/types.py
@@ -19,6 +19,16 @@ ClimateResponse = Dataset
 class ClimateParams:
     params: Dataset
 
+    @property
+    def median_params(self):
+        
+        pdropped = self.params.drop(["ghg_forcing","tropO3_forcing"])
+        pmedian = pdropped.median(dim="simulation")
+        pmedian["ghg_forcing"] = self.params["ghg_forcing"]
+        pmedian["tropO3_forcing"] = self.params["tropO3_forcing"]
+        
+        return pmedian
+
 # @dataclass # @@@ can this be a dataclass and a Protocol??
 # class Emissions():#Protocol? can't be instantiated
 #     emissions: DataArray # note can be year x gas or just year @@@


### PR DESCRIPTION
Add `median_params` property to `ClimateParams` and allow user to specify a `simid="median"` when setting up the FairModel.