### PR TITLE
refactor FairModel instantiation, ClimateParams, debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,30 @@ response.temperature.plot()
 
 ```
 
+### Run v1.* FaIR with demo emissions (CMIP5 RCP4.5) and climate parameters
+
+```python
+
+import scmcoat as sc
+
+# initialize the model
+fm = sc.core.FairModel(
+       sc.core.ClimateParams(xr.open_dataset(params_filepath))
+       )
+
+# Open up the test emissions to use as a demo
+emissions = fm.get_test_emissions()
+
+# run FaIR with these emissions and median climate parameters
+response = fm.run(emissions, simid="median")  # an xr.Dataset
+
+response.temperature.plot()
+
+# the model can be run with differen climate parameters
+response2 = fm.run(emissions, simid=150)
+
+_ = xr.concat([response,response2], dim="simulation").temperature.plot.line(x="year")
+
+```
+
 FaIR can run any emissions pathway in this format, although may become unstable under radically different emissions. Note this has not been tested with different length time series of emissions.

--- a/src/scmcoat/types.py
+++ b/src/scmcoat/types.py
@@ -1,33 +1,16 @@
-from dataclasses import dataclass
-from typing import Protocol
-from xarray import Dataset, DataArray
-from pandas import DataFrame
+# from scmcoat.core import ClimateParams
 
-#TODO: require specific climate param settings for FaIR?
-# ClimateParams = Dataset
-ClimateResponse = Dataset
+# from dataclasses import dataclass
+# from typing import Protocol
+# from xarray import Dataset, DataArray
+# from pandas import DataFrame
+
+# ClimateResponse = Dataset
 
 # TODO: how to enforce a specific format for Emissions?
 # Emissions = DataArray# note can be year x gas or just year @@@
 
 
-# TODO: Should require "beta0", "beta1" and "beta2" variables in this
-# QuadraticDamageCoefficients = Dataset
-
-
-@dataclass
-class ClimateParams:
-    params: Dataset
-
-    @property
-    def median_params(self):
-        
-        pdropped = self.params.drop(["ghg_forcing","tropO3_forcing"])
-        pmedian = pdropped.median(dim="simulation")
-        pmedian["ghg_forcing"] = self.params["ghg_forcing"]
-        pmedian["tropO3_forcing"] = self.params["tropO3_forcing"]
-        
-        return pmedian
 
 # @dataclass # @@@ can this be a dataclass and a Protocol??
 # class Emissions():#Protocol? can't be instantiated
@@ -38,10 +21,10 @@ class ClimateParams:
 #         returns list of emissions gases in correct order
 #         """
 
-class ClimateModel(Protocol):
-    def run(self, x: DataFrame, y: ClimateParams) -> ClimateResponse:
-        """
-        A ClimateModel can project change in global mean surface temp given GHG emissions
-        """
+# class ClimateModel(Protocol):
+#     def run(self, x: DataFrame, y: ClimateParams) -> ClimateResponse:
+#         """
+#         A ClimateModel can project change in global mean surface temp given GHG emissions
+#         """
 
-    # TODO add inverse run
+#     # TODO add inverse run


### PR DESCRIPTION
`ClimateParams` now live in scmcoat.core instead of scmcoat.types

Now instantiate `FairModel` with `ClimateParams` directly
```
fm = scmcoat.core.FairModel(
   params=sc.core.ClimateParams(params=xr.open_dataset(param_filepath)))
```