### PR TITLE
Improve scmcoat to handle different emissions series lengths and start years

### DIFF
--- a/src/scmcoat/core.py
+++ b/src/scmcoat/core.py
@@ -201,10 +201,10 @@ class FairModel:
                     F_solar = np.zeros(nt)
                     F_volcanic = np.zeros(nt)
                     natural = np.zeros((nt, 2))
-                    F_solar[:361] = args["F_solar"]
-                    F_volcanic[:361] = args["F_volcanic"]
-                    natural[:361, :] = args["natural"]
-                    natural[361:, :] = args["natural"][
+                    F_solar[:argslength] = args["F_solar"]
+                    F_volcanic[:argslength] = args["F_volcanic"]
+                    natural[:argslength, :] = args["natural"]
+                    natural[argslength:, :] = args["natural"][
                                     -1, :
                                 ]  
                     # do something to add solar/volc/nat to inputs
@@ -213,9 +213,9 @@ class FairModel:
                     F_solar = np.zeros(nt)
                     F_volcanic = np.zeros(nt)
                     natural = np.zeros((nt, 2))
-                    F_solar[:nt] = args["F_solar"]
-                    F_volcanic[:nt] = args["F_volcanic"]
-                    natural[:nt, :] = args["natural"]
+                    F_solar = args["F_solar"][:nt]
+                    F_volcanic = args["F_volcanic"][:nt]
+                    natural = args["natural"][:nt, :]
                 else: 
                     # they are equal, just set them directly
                     F_solar = np.zeros(nt)

--- a/src/scmcoat/core.py
+++ b/src/scmcoat/core.py
@@ -195,12 +195,12 @@ class FairModel:
             else:
                 nt = emiss.shape[0] # assume time length is same as input emissions. assume no change in ref year
                 argslength = args["F_solar"].shape[0] # assume solar, volc, natural have same time dim
-                F_solar = np.zeros(nt)
-                F_volcanic = np.zeros(nt)
-                natural = np.zeros((nt, 2))
                 
                 # assuming solar/volc/nat have same start year as emiss
                 if argslength < nt:
+                    F_solar = np.zeros(nt)
+                    F_volcanic = np.zeros(nt)
+                    natural = np.zeros((nt, 2))
                     F_solar[:nt] = args["F_solar"]
                     F_volcanic[:nt] = args["F_volcanic"]
                     natural[:361, :] = args["natural"]
@@ -210,11 +210,17 @@ class FairModel:
                     # do something to add solar/volc/nat to inputs
                 elif argslength > nt:
                     # do something to chop off end of solar/volc/nat args
+                    F_solar = np.zeros(nt)
+                    F_volcanic = np.zeros(nt)
+                    natural = np.zeros((nt, 2))
                     F_solar[:nt] = args["F_solar"]
                     F_volcanic[:nt] = args["F_volcanic"]
                     natural[:nt, :] = args["natural"]
                 else: 
                     # they are equal, just set them directly
+                    F_solar = np.zeros(nt)
+                    F_volcanic = np.zeros(nt)
+                    natural = np.zeros((nt, 2))
                     F_solar[:nt] = args["F_solar"]
                     F_volcanic[:nt] = args["F_volcanic"]
                     natural[:nt, :] = args["natural"]

--- a/src/scmcoat/core.py
+++ b/src/scmcoat/core.py
@@ -201,8 +201,8 @@ class FairModel:
                     F_solar = np.zeros(nt)
                     F_volcanic = np.zeros(nt)
                     natural = np.zeros((nt, 2))
-                    F_solar[:nt] = args["F_solar"]
-                    F_volcanic[:nt] = args["F_volcanic"]
+                    F_solar[:361] = args["F_solar"]
+                    F_volcanic[:361] = args["F_volcanic"]
                     natural[:361, :] = args["natural"]
                     natural[361:, :] = args["natural"][
                                     -1, :

--- a/src/scmcoat/core.py
+++ b/src/scmcoat/core.py
@@ -195,7 +195,10 @@ class FairModel:
             else:
                 nt = emiss.shape[0] # assume time length is same as input emissions. assume no change in ref year
                 argslength = args["F_solar"].shape[0] # assume solar, volc, natural have same time dim
-
+                F_solar = np.zeros(nt)
+                F_volcanic = np.zeros(nt)
+                natural = np.zeros((nt, 2))
+                
                 # assuming solar/volc/nat have same start year as emiss
                 if argslength < nt:
                     F_solar[:nt] = args["F_solar"]

--- a/src/scmcoat/core.py
+++ b/src/scmcoat/core.py
@@ -193,7 +193,28 @@ class FairModel:
                     -1, :
                 ]  # hold the last element constant for the rest of the array
             else:
-                raise NotImplementedError("Unable to handle emissions other than lengths 736 or 751")
+                nt = emiss.shape[0] # assume time length is same as input emissions. assume no change in ref year
+                argslength = args["F_solar"].shape[0] # assume solar, volc, natural have same time dim
+
+                # assuming solar/volc/nat have same start year as emiss
+                if argslength < nt:
+                    F_solar[:nt] = args["F_solar"]
+                    F_volcanic[:nt] = args["F_volcanic"]
+                    natural[:361, :] = args["natural"]
+                    natural[361:, :] = args["natural"][
+                                    -1, :
+                                ]  
+                    # do something to add solar/volc/nat to inputs
+                elif argslength > nt:
+                    # do something to chop off end of solar/volc/nat args
+                    F_solar[:nt] = args["F_solar"]
+                    F_volcanic[:nt] = args["F_volcanic"]
+                    natural[:nt, :] = args["natural"]
+                else: 
+                    # they are equal, just set them directly
+                    F_solar[:nt] = args["F_solar"]
+                    F_volcanic[:nt] = args["F_volcanic"]
+                    natural[:nt, :] = args["natural"]
 
             C, F, T, ariaci, lambda_eff, ohc, heatflux = fair.forward.fair_scm(
                 emissions=emiss,
@@ -272,7 +293,8 @@ class FairModel:
         elif emiss.shape[0] == 751:
             reference_year = 1750
         else:
-            raise NotImplementedError("emissions time dimension is not recognized")
+            reference_year = 1750
+            #raise NotImplementedError("emissions time dimension is not recognized")
 
         ret = self._run(emiss=emiss.values, 
                         useMultigas=useMultigas)

--- a/src/scmcoat/core.py
+++ b/src/scmcoat/core.py
@@ -297,14 +297,11 @@ class FairModel:
         
         # default time dimensions for different versions of FaIR v1.*
         # TODO check if other time dimensions work
-        if emiss.shape[0] == 736:
-            reference_year = 1765   
-        elif emiss.shape[0] == 751:
-            reference_year = 1750
-        else:
+        #if emiss.shape[0] == 736:
+            #reference_year = 1765   
+        #elif emiss.shape[0] == 751:
             #reference_year = 1750
-            #raise NotImplementedError("emissions time dimension is not recognized")
-
+            
         ret = self._run(emiss=emiss.values, 
                         useMultigas=useMultigas)
 

--- a/src/scmcoat/core.py
+++ b/src/scmcoat/core.py
@@ -167,7 +167,7 @@ class FairModel:
             # TODO generalize time dim. 
             # TODO test different length of emissions time series
             if emiss.shape[0] == 736:
-                reference_year = 1765
+                #reference_year = 1765
 
                 nt = 736 
                 F_solar = np.zeros(nt)
@@ -180,7 +180,7 @@ class FairModel:
                     -1, :
                 ]  # hold the last element constant for the rest of the array
             elif emiss.shape[0] == 751:
-                reference_year = 1750
+                #reference_year = 1750
 
                 nt = 751 
                 F_solar = np.zeros(nt)
@@ -302,7 +302,7 @@ class FairModel:
         elif emiss.shape[0] == 751:
             reference_year = 1750
         else:
-            reference_year = 1750
+            #reference_year = 1750
             #raise NotImplementedError("emissions time dimension is not recognized")
 
         ret = self._run(emiss=emiss.values, 
@@ -311,7 +311,7 @@ class FairModel:
         # Prep the FaIR outputs into xarray objects
 
         # TODO generalize the years
-        years = np.arange(reference_year, 2501)  # gets range of years in desired period
+        years = emiss.year.values  # gets range of years in desired period
         gases = (
             self.get_list_of_concentration_gases()
         )  # gets list of gases names from this function defined above


### PR DESCRIPTION
Edits in definition of FairModel run and default time dimensions that allow different emissions time series lengths and start years to run successfully