### PR TITLE
add ocean heat content to FaIR output

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Data variables:
     concentration  (year, gas) float64 278.0 722.0 273.0 ... 13.22 620.6
     forcing        (year, forcing_type) float64 2.623e-05 0.0 0.0 ... 0.0 0.0
     temperature    (year) float64 0.005061 0.009262 0.01363 ... 3.244 3.245
+    ocean_heat_content (year) float64 4.358e+21 7.791e+21 ... 5.822e+24
     simulation     () <U7 'default'
 ```
 Here a `simulation` equal to "default" indicates it's not running an ensemble of simulations with climate parameters but rather is running with default FaIR settings.

--- a/src/scmcoat/core.py
+++ b/src/scmcoat/core.py
@@ -323,9 +323,23 @@ class FairModel:
             coords=[years],
             name="temperature",
         )
-        response_ds = xr.merge(
-            [C_xarray, F_xarray, T_xarray]
-        )
+        if len(ret) == 7:
+            ohc_xarray = xr.DataArray(
+                ohc,
+                dims=[
+                    "year",
+                ],
+                coords=[years],
+                name="ocean_heat_content",
+            )
+            response_ds = xr.merge(
+                [C_xarray, F_xarray, T_xarray, ohc_xarray]
+            )
+        else:
+            
+            response_ds = xr.merge(
+                [C_xarray, F_xarray, T_xarray]
+            )
         response_ds["simulation"] = self.simid
         
         # TODO Add attributes


### PR DESCRIPTION
Under certain settings, `fair.forward.fair_scm` returns extra variables that are ignored in the `xr.Dataset` returned from `scmcoat.core.run`. This PR adds a `ocean_heat_content` variable to the `xr.Dataset`, which is helpful for understanding thermosteric sea level rise (sea level rise due to thermal expansion).