### PR TITLE
Update emissions units list and forcing coord

### DIFF
--- a/src/scmcoat/core.py
+++ b/src/scmcoat/core.py
@@ -365,10 +365,10 @@ class FairModel:
 
 
     def get_test_emissions(self):
-        import pandas as pd
-        import pkg_resources
+        # import pandas as pd
+        # import pkg_resources
         from . import utils
-                
+        print("get_test_emissions() @@@@@")
         # without further updates, FaIR versions < 2 run in default mode
         # expect the start year to be 1765
         return utils.rcmip_emissions("ssp245").sel(year=slice(1765, None))

--- a/src/scmcoat/core.py
+++ b/src/scmcoat/core.py
@@ -365,10 +365,8 @@ class FairModel:
 
 
     def get_test_emissions(self):
-        # import pandas as pd
-        # import pkg_resources
         from . import utils
-        print("get_test_emissions() @@@@@")
+        
         # without further updates, FaIR versions < 2 run in default mode
         # expect the start year to be 1765
         return utils.rcmip_emissions("ssp245").sel(year=slice(1765, None))

--- a/src/scmcoat/core.py
+++ b/src/scmcoat/core.py
@@ -295,13 +295,30 @@ class FairModel:
             raise NotImplementedError(f"FaIR output unrecognized. Expecting length of 3 or 7, got {len(ret)}")
 
         if useMultigas:
+                
             C_xarray = xr.DataArray(
                 C, dims=["year", "gas"], coords=[years, gases], name="concentration"
             )
+            if F.shape[1] == 13:
+                Fcoord = [
+                    "CO2", "CH4", "N2O",
+                    "Minor GHGs (CFCs, HFCs etc)",
+                    "Tropospheric ozone",
+                    "Stratospheric ozone",
+                    "Stratospheric water vapour from methane oxidation",
+                    "Contrails",
+                    "Aerosols",
+                    "Black carbon on snow",
+                    "Land use",
+                    "Volcanic",
+                    "Solar",
+                ]
+            else:
+                Fcoord = np.arange(0, F.shape[1])
             F_xarray = xr.DataArray(
                 F,
                 dims=["year", "forcing_type"],
-                coords=[years, np.arange(0, F.shape[1])],
+                coords=[years, Fcoord],
                 name="forcing",
             )
         else:

--- a/src/scmcoat/utils.py
+++ b/src/scmcoat/utils.py
@@ -32,7 +32,7 @@ def rcmip_emissions(scenario):
     units = ['Gt C/year',
              'Gt C/year',
              'Mt CH4/yr',
-             'tonnes N2/year',
+             'Mt N2/year',
              'Mt S/year',
              'Mt CO/yr',
              'Mt VOC/yr',


### PR DESCRIPTION
Listed units for N2O emissions were incorrectly stated as "tonnes N2/yr".

Compare the list in `scmcoat`
https://github.com/kemccusker/scmcoat/blob/d8abd1109aee040a91aa7e849067ff9b7ed54deb/src/scmcoat/utils.py#L32

with the list request by v1.6.4 of `fair`
https://github.com/OMS-NetZero/FAIR/blob/1659d751a12003af22b5bfa9ff1af74a21566582/src/fair/structure/units.py#L26
